### PR TITLE
GitHub worker supervision / resiliency

### DIFF
--- a/src/app/PortfoliOSS.ModernDomain/Actors/GithubClientActor.cs
+++ b/src/app/PortfoliOSS.ModernDomain/Actors/GithubClientActor.cs
@@ -27,6 +27,14 @@ namespace PortfoliOSS.ModernDomain.Actors
         private List<string> _usersCheckedForForksAndSources = new List<string>();
         private List<DonatedGitHubToken> _tokens;
 
+        protected override SupervisorStrategy SupervisorStrategy()
+        {
+            return new OneForOneStrategy(
+                maxNrOfRetries: 10,
+                withinTimeRange: TimeSpan.FromMinutes(1),
+                localOnlyDecider: ex => Directive.Restart);
+        }
+
         public GithubClientActor(List<DonatedGitHubToken> tokens)
         {
             _tokens = tokens;

--- a/src/app/PortfoliOSS.ModernDomain/Actors/GithubWorkerActor.cs
+++ b/src/app/PortfoliOSS.ModernDomain/Actors/GithubWorkerActor.cs
@@ -19,6 +19,18 @@ namespace PortfoliOSS.ModernDomain.Actors
         private readonly ActorSelection _orgManager;
         public IStash Stash { get; set; }
 
+        protected override void PreRestart(Exception reason, object message)
+        {
+            _logger.Error(reason, "Stashing all messages and preparing to restart");
+            Stash.Stash();
+        }
+
+        protected override void PostRestart(Exception reason)
+        {
+            _logger.Error(reason, "Recovering after restart and unstashing all messages");
+            Stash.UnstashAll();
+        }
+
         public GithubWorkerActor(string appName, string apiKey)
         {
             _userManager = Context.ActorSelection(Constants.ActorPaths.USER_MANAGER);

--- a/src/app/PortfoliOSS.ModernDomain/Actors/GithubWorkerActor.cs
+++ b/src/app/PortfoliOSS.ModernDomain/Actors/GithubWorkerActor.cs
@@ -68,6 +68,10 @@ namespace PortfoliOSS.ModernDomain.Actors
                 {
                     RateLimitExceeded(ex);
                 }
+                catch (ForbiddenException ex)
+                {
+                    RateLimitExceeded(ex);
+                }
                 catch (Exception ex)
                 {
                     _logger.Error(ex, "Error occurred");
@@ -101,6 +105,10 @@ namespace PortfoliOSS.ModernDomain.Actors
                 {
                     RateLimitExceeded(ex);
                 }
+                catch (ForbiddenException ex)
+                {
+                    RateLimitExceeded(ex);
+                }
                 catch (Exception ex)
                 {
                     _logger.Error(ex, "Error occurred");
@@ -126,6 +134,10 @@ namespace PortfoliOSS.ModernDomain.Actors
                 {
                     RateLimitExceeded(ex);
                 }
+                catch (ForbiddenException ex)
+                {
+                    RateLimitExceeded(ex);
+                }
                 catch (Exception ex)
                 {
                     _logger.Error(ex, "Error occurred");
@@ -141,6 +153,10 @@ namespace PortfoliOSS.ModernDomain.Actors
 
                 }
                 catch (RateLimitExceededException ex)
+                {
+                    RateLimitExceeded(ex);
+                }
+                catch (ForbiddenException ex)
                 {
                     RateLimitExceeded(ex);
                 }
@@ -195,6 +211,10 @@ namespace PortfoliOSS.ModernDomain.Actors
                 {
                     RateLimitExceeded(ex);
                 }
+                catch (ForbiddenException ex)
+                {
+                    RateLimitExceeded(ex);
+                }
                 catch (Exception ex)
                 {
                     _logger.Error(ex, "Error occurred");
@@ -213,6 +233,10 @@ namespace PortfoliOSS.ModernDomain.Actors
                     _orgManager.Tell(new AddOrgCommand(result.Login, result.Id));
                 }
                 catch (RateLimitExceededException ex)
+                {
+                    RateLimitExceeded(ex);
+                }
+                catch (ForbiddenException ex)
                 {
                     RateLimitExceeded(ex);
                 }
@@ -239,9 +263,20 @@ namespace PortfoliOSS.ModernDomain.Actors
             });
         }
 
+        private void RateLimitExceeded(ForbiddenException ex)
+        {
+            var timeToPause = TimeSpan.FromMinutes(15);
+            ErrorAndPaused(ex, timeToPause);
+        }
+
         private void RateLimitExceeded(RateLimitExceededException ex)
         {
             var timeToPause = ex.GetRetryAfterTimeSpan().Add(TimeSpan.FromMinutes(1));
+            ErrorAndPaused(ex, timeToPause);
+        }
+
+        private void ErrorAndPaused(Exception ex, TimeSpan timeToPause)
+        {
             _logger.Error(ex, "Received an error -- pausing for {MinutesToPause} minutes", timeToPause.TotalMinutes);
             Context.System.Scheduler.ScheduleTellOnce(timeToPause, Self, new Resume(), Self);
             Become(Paused);


### PR DESCRIPTION
Closes #40.
Closes #41.

The GitHub workers tended to encounter a few problems:

* Typical draw-down toward rate limiting. We were already prepared for this.
* In some situations, the rate limit changed or we hit a secondary rate limit. In this case we'd receive an exception but weren't prepared to deal with it.
* Server errors that can occur because GitHub isn't fault-proof.
* When unhandled errors occurred, the messages for that actor were not stashed but lost.

So, this PR:

* Stashes / unstashes messages upon actor restart (in the case of transient GitHub server errors)
* Pauses the actors when an API Rate Limit Exception is encountered
* Similarly, pauses when a "Forbidden" error is encountered, as I think this actually has to do with a secondary rate limit.